### PR TITLE
Remove inline example from index and add demo file

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -3,15 +3,15 @@ import { calculateProfitFromTxHash, displayProfitResults } from "./index";
 // Run calculation with example data
 async function runExample() {
   try {
-    const profit = await calculateProfitFromTxHash(
-      "0x4eaa9a30fabe363c883a557765f1512747011304db589dcc686156b42b613d5e"
-    );
+    // Example using transaction hash
+    const txHash = "0x4eaa9a30fabe363c883a557765f1512747011304db589dcc686156b42b613d5e";
+    const results = await calculateProfitFromTxHash(txHash);
 
-    displayProfitResults(profit);
+    await displayProfitResults(results);
   } catch (error) {
     console.error("Error calculating profit:", error);
   }
 }
 
 // Execute the example
-runExample();
+runExample().catch(console.error);

--- a/index.ts
+++ b/index.ts
@@ -218,20 +218,3 @@ export async function displayProfitResults(
   console.log(`Total Profit: $${totalProfit.toFixed(2)}`);
 }
 
-// Example usage
-if (require.main === module) {
-  const runExample = async () => {
-    try {
-      // Example using transaction hash
-      const txHash =
-        "0x4eaa9a30fabe363c883a557765f1512747011304db589dcc686156b42b613d5e";
-      const results = await calculateProfitFromTxHash(txHash);
-
-      await displayProfitResults(results);
-    } catch (error) {
-      console.error("Error calculating profit:", error);
-    }
-  };
-
-  runExample().catch(console.error);
-}


### PR DESCRIPTION
## Summary
- remove bundled example usage from `index.ts` to keep library side-effect free
- add standalone `example.ts` script demonstrating how to compute and display profit results

## Testing
- `npm test` *(fails: Cannot find module 'test-api.js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cbc6a26e4832b822bbfb18ac13a29